### PR TITLE
Update usage of Shapefile.Rect to be nonparametric, closes #4

### DIFF
--- a/src/choropleth.jl
+++ b/src/choropleth.jl
@@ -39,7 +39,7 @@ function choropleth(shapes::AbstractArray{T, 1}, canvas::Compose.Context,
 end
 
 # Plot choropleth - given array of shapes and an MBR
-function choropleth(shapes::AbstractArray{T, 1}, MBR::Shapefile.Rect{Float64},
+function choropleth(shapes::AbstractArray{T, 1}, MBR::Shapefile.Rect,
                     fill_data, fill_color_map;
                     convertcoords=lonlat_to_webmercator, img_width=12cm,
                     options...) where {T<:Shapefile.GeoInterface.AbstractGeometry}

--- a/src/plotshape.jl
+++ b/src/plotshape.jl
@@ -21,7 +21,7 @@ end
 
 # Plot Shapefile - given array of shapes and an MBR
 function plotshape(shparray::AbstractArray{T, 1},
-                   MBR::Shapefile.Rect{Float64};
+                   MBR::Shapefile.Rect;
                    convertcoords=lonlat_to_webmercator, img_width=12cm,
                    options...) where {T<:AbstractGeom}
 
@@ -51,7 +51,7 @@ function plotshape(shp::Shapefile.Handle; options...)
 end
 
 # Plot Shapefile - given the Shapefile Handle and an MBR
-function plotshape(shp::Shapefile.Handle, MBR::Shapefile.Rect{Float64}; options...)
+function plotshape(shp::Shapefile.Handle, MBR::Shapefile.Rect; options...)
     plotshape(shp.shapes, MBR; options...)
 end
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -19,7 +19,7 @@ x0 := left, y0 := top, width := right-left, height := -(top-bottom)
 The UnitBox typically has origin at top left and moves down and right (an image convention).
 To change to the convention of having the origin at the bottom left we use a negative height.
 =#
-function create_canvas(MBR::Shapefile.Rect{Float64}, convertcoords, img_width)
+function create_canvas(MBR::Shapefile.Rect, convertcoords, img_width)
 
     # Coordinate conversion
     left, top = convertcoords(MBR.left, MBR.top)


### PR DESCRIPTION
`Shapefile.Rect` is no longer a parametric type.